### PR TITLE
added error handler for HTTP 409_CONFLICT

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -70,6 +70,17 @@ def method_not_supported(error):
     )
 
 
+@app.errorhandler(status.HTTP_409_CONFLICT)
+def conflict(error):
+    """Handles resources not found with 409_CONFLICT"""
+    message = str(error)
+    app.logger.warning(message)
+    return (
+        jsonify(status=status.HTTP_409_CONFLICT, error="Conflict", message=message),
+        status.HTTP_409_CONFLICT,
+    )
+
+
 @app.errorhandler(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 def mediatype_not_supported(error):
     """Handles unsupported media requests with 415_UNSUPPORTED_MEDIA_TYPE"""

--- a/service/routes.py
+++ b/service/routes.py
@@ -94,7 +94,7 @@ def create_recommendations():
     ).first()
 
     if existing_recommendation:
-        return error(status.HTTP_409_CONFLICT, "Duplicate recommendation detected.")
+        error(status.HTTP_409_CONFLICT, "Duplicate recommendation detected.")
 
     recommendation = Recommendation()
     recommendation.deserialize(request.get_json())

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -223,3 +223,6 @@ class TestRecommendationService(TestCase):
         # Attempt to create a duplicate recommendation, which should fail
         response = self.client.post(BASE_URL, json=recommendation_data)
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertIn(
+            "Duplicate recommendation detected.", response.get_json()["message"]
+        )


### PR DESCRIPTION
Changes:
 - added error handler for HTTP 409_CONFLICT in `service/common/error_handler.py`
 - added assertion of error message in the test of creating duplicates
 - remove the unnecessary `return` in `service/routes.py`