### PR TITLE
Add filtering to Recommendation model

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -213,6 +213,12 @@ class Recommendation(db.Model):
     @classmethod
     def find_by_product_a_sku_and_type(cls, product_a_sku, recommendation_type):
         """Find recommendations by product A SKU and type, ordered by likes."""
+        logger.info(
+            "Processing type query for %s and %s...",
+            product_a_sku,
+            recommendation_type.name,
+        )
+
         return (
             cls.query.filter_by(
                 product_a_sku=product_a_sku, recommendation_type=recommendation_type

--- a/service/models.py
+++ b/service/models.py
@@ -50,6 +50,7 @@ class Recommendation(db.Model):
     product_a_sku = db.Column(db.String(SKU_CHAR_LIMIT), nullable=False)
     product_b_sku = db.Column(db.String(SKU_CHAR_LIMIT), nullable=False)
     recommendation_type = db.Column(db.Enum(RecommendationType), nullable=False)
+    likes = db.Column(db.Integer, default=0, nullable=False)
 
     name = f"{product_a_sku}-{product_b_sku}"
 
@@ -194,3 +195,14 @@ class Recommendation(db.Model):
         """
         logger.info("Processing type query for %s ...", recommendation_type.name)
         return cls.query.filter(cls.recommendation_type == recommendation_type)
+
+    @classmethod
+    def find_by_product_a_sku_and_type(cls, product_a_sku, recommendation_type):
+        """Find recommendations by product A SKU and type, ordered by likes."""
+        return (
+            cls.query.filter_by(
+                product_a_sku=product_a_sku, recommendation_type=recommendation_type
+            )
+            .order_by(cls.likes.desc())
+            .all()
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -359,3 +359,41 @@ class TestModelQueries(TestCaseBase):
         self.assertEqual(found.count(), count)
         for recommendation in found:
             self.assertEqual(recommendation.recommendation_type, recommendation_type)
+
+    def test_find_by_product_a_sku_and_type(self):
+        """It should filter recommendations by product_a_sku and type and return them ordered by likes"""
+        Recommendation(
+            product_a_sku="SKU1",
+            product_b_sku="SKU2",
+            recommendation_type=RecommendationType.UP_SELL,
+            likes=10,
+        ).create()
+        Recommendation(
+            product_a_sku="SKU1",
+            product_b_sku="SKU3",
+            recommendation_type=RecommendationType.UP_SELL,
+            likes=20,
+        ).create()
+        Recommendation(
+            product_a_sku="SKU1",
+            product_b_sku="SKU4",
+            recommendation_type=RecommendationType.CROSS_SELL,
+            likes=15,
+        ).create()
+
+        # Call the method under test
+        results = Recommendation.find_by_product_a_sku_and_type(
+            "SKU1", RecommendationType.UP_SELL
+        )
+
+        # Assert the results are as expected
+        self.assertEqual(len(results), 2)
+        self.assertTrue(
+            all(
+                rec.recommendation_type == RecommendationType.UP_SELL for rec in results
+            )
+        )
+        self.assertEqual(
+            results[0].product_b_sku, "SKU3"
+        )  # Assuming the first result is the most liked
+        self.assertEqual(results[1].product_b_sku, "SKU2")


### PR DESCRIPTION
Implemented the `find_by_product_a_sku_and_type` method within the `Recommendation` model to enable filtering of recommendations by `product_a_sku` and `recommendation_type`, with results ordered by the `likes` attribute.